### PR TITLE
This has a working fix for the original issue #8 and now #9, Triggers executing multiple times

### DIFF
--- a/Windows.UI.Interactivity/Windows.UI.Interactivity.csproj.user
+++ b/Windows.UI.Interactivity/Windows.UI.Interactivity.csproj.user
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <ProjectView>ShowAllFiles</ProjectView>
+    <ProjectView>ProjectFiles</ProjectView>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
the WindowsRuntimeMarshal.AddEventHandler<> and
WindowsRuntimeMarshal.RemoveEventHandler<> were using a different pair
of inline Action<>'s (one fro each call); both calls need to reference
the same delegate
