### PR TITLE
Fixed TargetedTriggerAction 

### DIFF
--- a/Windows.UI.Interactivity/TargetedTriggerAction.cs
+++ b/Windows.UI.Interactivity/TargetedTriggerAction.cs
@@ -18,8 +18,8 @@ namespace Windows.UI.Interactivity
     /// </remarks>
     public abstract class TargetedTriggerAction : TriggerAction
     {
-        public static readonly DependencyProperty TargetObjectProperty = DependencyProperty.Register("TargetObject", typeof(object), typeof(TargetedTriggerAction), new PropertyMetadata(new PropertyChangedCallback(TargetedTriggerAction.OnTargetObjectChanged)));
-        public static readonly DependencyProperty TargetNameProperty = DependencyProperty.Register("TargetName", typeof(string), typeof(TargetedTriggerAction), new PropertyMetadata(new PropertyChangedCallback(TargetedTriggerAction.OnTargetNameChanged)));
+        public static readonly DependencyProperty TargetObjectProperty = DependencyProperty.Register("TargetObject", typeof(object), typeof(TargetedTriggerAction), new PropertyMetadata(null, new PropertyChangedCallback(TargetedTriggerAction.OnTargetObjectChanged)));
+        public static readonly DependencyProperty TargetNameProperty = DependencyProperty.Register("TargetName", typeof(string), typeof(TargetedTriggerAction), new PropertyMetadata(null, new PropertyChangedCallback(TargetedTriggerAction.OnTargetNameChanged)));
         private Type targetTypeConstraint;
         private bool isTargetChangedRegistered;
         private NameResolver targetResolver;


### PR DESCRIPTION
Fixed incorrect DependencyProperty initialization in TargetedTriggerAction which causes InvalidCastException

jlaanstra, do you use ReSharper or something similar?
You deleted "null, " from new PropertyMetadata(null, new PropertyChangedCallback(TargetedTriggerAction.OnTargetObjectChanged)));
So default value becomes of type PropertyChangedCallback on TargetObjectProperty and TargetNameProperty on TargetedTriggerAction type.

Please, apply and update NuGet package as soon as possible. It is critical issue!
